### PR TITLE
chore: bump shiki peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
-    "shiki": "^0.10.0"
+    "shiki": "^0.12.0"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
Hello !
It's time to bump shiki to last stable version 🚀 

I'm actually blocked by the peer dependency mismatch between my own shiki dependency using last version and this one.